### PR TITLE
Default local dev stack to live-reload (USE_DEV=1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ export DOCKER_BUILDKIT=0
 
 COMPOSE_BASE=docker-compose.yml
 COMPOSE_DEV=docker-compose.dev.yml
-USE_DEV?=0
+USE_DEV?=1
 
 ifeq ($(USE_DEV),1)
 COMPOSE_FILES=$(COMPOSE_BASE) $(COMPOSE_DEV)
@@ -16,7 +16,9 @@ COMPOSE_CMD=docker compose $(foreach file,$(COMPOSE_FILES),-f $(file))
 
 # `up` starts the full local Supabase stack (Postgres + API/Kong + Auth +
 # Storage + Studio) via the Supabase CLI, applying migrations and seed, THEN
-# brings up Temporal + worker + frontend via docker compose.
+# brings up Temporal + worker + frontend via docker compose. Live-reload
+# (docker-compose.dev.yml) is on by default; pass USE_DEV=0 for a frozen
+# built-image run instead.
 up:
 	supabase start
 	@eval "$$(./scripts/supabase-env.sh)"; $(COMPOSE_CMD) up -d

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Phase 1 scaffolding for the JSON-driven Supabase + Temporal starter.
    `cp .env.example .env`
 2) Start everything  
    `make up`  
-   (add `USE_DEV=1` for live-reload mounts)  
+   (live-reload mounts for frontend/worker are on by default; pass `USE_DEV=0 make up` for a frozen built-image run instead)  
    This runs `supabase start` (Postgres + API + Auth + Studio, with migrations and seed applied), then brings up Temporal, the worker, and the frontend.
 3) Open services  
    - Frontend: http://localhost:53900  

--- a/docs/specs/0007-default-dev-stack-live-reload-plan.md
+++ b/docs/specs/0007-default-dev-stack-live-reload-plan.md
@@ -1,0 +1,39 @@
+# Implementation Plan: Default Dev Stack to Live-Reload
+
+**Spec:** [0007-default-dev-stack-live-reload.md](./0007-default-dev-stack-live-reload.md)
+**Ticket:** Closes #16
+**Status:** Approved (Gate 1) — implemented and live-verified 2026-09-01.
+
+## Implementation notes (deviations from the plan as written)
+
+- `make` itself is not installed on this machine (Windows/Git Bash — matches the known gotcha for this repo family). Verification below exercises the exact command sequences the Makefile's `up` target now runs by default (`docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d`) rather than literally invoking `make up`/`make down`/`make reset`. The Makefile logic itself (`ifeq ($(USE_DEV),1)`) is unchanged from the prior working version — only the default value flipped — so this is not expected to behave differently under real `make`.
+- Did not test `make down`/`make reset` end-to-end (no `make` binary available); the compose/`supabase stop` commands they wrap were already exercised in this and prior sessions and are unaffected by this change (it only touches which files are layered on `up`).
+
+## Phase 1: `Makefile`
+
+- [x] `USE_DEV?=0` → `USE_DEV?=1`
+- [x] Header comment above `up` updated to state live-reload is on by default and `USE_DEV=0` is the opt-out
+
+## Phase 2: `README.md`
+
+- [x] Quick Start's `make up` step updated: live-reload on by default, `USE_DEV=0 make up` documented as the frozen-image opt-out
+- [x] Scanned rest of `README.md` — no other `USE_DEV` mentions found
+
+## Phase 3: Verification
+
+- [x] Confirmed default (dev) path: `docker inspect resume-frontend` showed `frontend/` bind-mounted live into `/app` (the config `make up` now produces by default)
+- [x] Frontend already reflects live source with this mount active (verified earlier this session — edited `frontend/src` picked up without rebuild)
+- [x] Opt-out path: ran the `USE_DEV=0` equivalent (`docker compose -f docker-compose.yml up -d --build frontend`, no dev overlay) — `docker inspect` showed zero mounts (frozen image), frontend still served `200`
+- [x] Restored default: ran the `USE_DEV=1`-equivalent command again — live mount confirmed back in place
+- [ ] `make down` / `make reset` — not run (see Implementation notes; no `make` binary on this machine)
+- [ ] Adversarial Ctrl-C-mid-up case — not run (same reason; the compose commands underneath are unchanged by this fix, so behavior on interrupt is not expected to differ from before)
+
+## Out of scope for this plan (per spec's Non-Goals)
+
+- Changing `docker-compose.dev.yml`'s mounts or mechanics
+- Renaming Makefile targets
+- Any change to `deploy/`/CI build behavior
+
+## Dependencies between phases
+
+Phase 1 must land before Phase 3 (verification exercises the new default). Phase 2 is independent of Phase 1 but should land alongside it in the same change.

--- a/docs/specs/0007-default-dev-stack-live-reload.md
+++ b/docs/specs/0007-default-dev-stack-live-reload.md
@@ -1,0 +1,68 @@
+# Default Dev Stack to Live-Reload Specification
+
+**Status:** Draft
+**Owner:** Ndumiso Mpanza
+**Created:** 2026-09-01
+**Last Updated:** 2026-09-01
+**Ticket:** Closes #16
+
+## Overview
+
+`make up` (i.e. `docker compose -f docker-compose.yml up`, `USE_DEV` unset/`0`) builds the frontend from a static image snapshot of `frontend/` at build time rather than mounting source live. Editing frontend code after `make up` shows no changes in the browser, with no indication in logs or UI that the running container is frozen rather than live. Only `USE_DEV=1 make up` (which layers `docker-compose.dev.yml`, bind-mounting `frontend/` and `temporal/src/`) reflects live edits. This spec makes live-reload the default local-dev path.
+
+## Goals
+
+- A plain `make up` gives live-reload for `frontend/` and `temporal/src/` by default — no `USE_DEV=1` needed
+- The frozen-image (non-dev) mode remains available for verification/CI-like local checks, opt-in rather than opt-out
+- README Quick Start documents the new default and how to opt into the frozen-image mode
+
+## Non-Goals
+
+- Changing what `docker-compose.dev.yml` mounts or how live-reload works internally — only which mode is the default
+- Renaming Makefile targets or changing `make down` / `make reset` behavior
+- Any change to production/deployed build behavior (`deploy/`, CI) — this is local dev only
+
+## User Stories
+
+### As the developer, I want `make up` to give me a live-reload frontend/worker by default, so that editing source code always shows up without extra flags or a manual rebuild
+
+**Acceptance Criteria:**
+- [ ] `make up` (no `USE_DEV` set) starts the stack with `docker-compose.dev.yml` layered in
+- [ ] Editing a file under `frontend/src/` while the stack from `make up` is running shows the change in the browser without a manual `docker compose up --build`
+- [ ] An explicit opt-out (e.g. `USE_DEV=0 make up`) still gives the frozen-image build for verification purposes
+- [ ] README Quick Start reflects the new default and documents the opt-out
+
+## Technical Design
+
+### Architecture
+
+No architectural change — flips the Makefile's default value for `USE_DEV` and updates docs to match. No application or compose-file changes beyond the default.
+
+### Changes
+
+- **`Makefile`**: `USE_DEV?=0` → `USE_DEV?=1`
+- **`README.md`**: Quick Start's `make up` step updated to note live-reload is the default; document `USE_DEV=0 make up` as the opt-out for a frozen-image run
+
+### Security Considerations
+
+None — dev-only local tooling default, no secrets or auth surface touched.
+
+### Risks and Mitigations
+
+| Risk | Impact | Probability | Mitigation |
+|------|--------|-------------|------------|
+| Someone relying on the old frozen-image default (e.g. to sanity-check a production-like build locally) gets live-reload unexpectedly | Low | Low | Document `USE_DEV=0 make up` opt-out clearly in README |
+
+## Testing Strategy
+
+- Manual: run `make up` with no `USE_DEV` set, confirm `docker compose ps` shows dev-overlay behavior (bind mounts present via `docker inspect`), edit a `frontend/src` file, confirm it's reflected in the browser without a rebuild
+- Manual: run `USE_DEV=0 make up`, confirm the frozen-image behavior still works (no live mount)
+- Adversarial: confirm `make down` / `make reset` still work correctly against the new default-dev stack
+
+## Open Questions
+
+- [ ] None
+
+## Approval
+
+- [ ] Ndumiso Mpanza


### PR DESCRIPTION
## Summary
- `make up` now mounts `frontend/`/`temporal/src` live by default (layers `docker-compose.dev.yml`) instead of silently serving a frozen built image
- `USE_DEV=0 make up` is the new opt-out for a frozen-image verification run
- README Quick Start updated to match; spec + plan added under `docs/specs/0007-*`

## Test plan
- [x] `docker inspect resume-frontend` confirms `frontend/` bind-mounted live under the new default
- [x] Edited `frontend/src`, confirmed change reflected without a manual rebuild
- [x] `USE_DEV=0` equivalent (`docker compose -f docker-compose.yml up -d --build frontend`) confirmed frozen-image opt-out still works (no live mount)
- [ ] `make down` / `make reset` — not run; `make` isn't installed on the dev machine used for this change, and these targets don't touch the changed logic

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)